### PR TITLE
Fix bug: FileInput constructor accepts checkinterval as seconds, however it is stored and treated as milliseconds.

### DIFF
--- a/source/LogFlow/Builtins/Inputs/FileInput.cs
+++ b/source/LogFlow/Builtins/Inputs/FileInput.cs
@@ -39,12 +39,12 @@ namespace LogFlow.Builtins.Inputs
 		{
 		}
 
-		public FileInput(string path, Encoding encoding, bool includeSubDirectories, int readBatchSize = 100, int checkIntervalSeconds = 30)
+		public FileInput(string path, Encoding encoding, bool includeSubDirectories, int readBatchSize = 100, int checkIntervalMilliseconds = 100)
 		{
 			_path = path;
 			_encoding = encoding;
 			_readBatchSize = readBatchSize;
-			_checkIntervalMiliseconds = checkIntervalSeconds;
+			_checkIntervalMiliseconds = checkIntervalMilliseconds;
 
 			_watcher = new FileSystemWatcher(GetPath(), GetSearchPattern()) {IncludeSubdirectories = includeSubDirectories};
 			_watcher.Changed += (sender, args) => AddToQueueWithDuplicationCheck(args.FullPath);


### PR DESCRIPTION
Change name of parameter and set the default to 100, which is minimum according to the setter on `CheckIntervalMiliseconds`.

The alternative would have been to actually treat `checkIntervalSeconds` as seconds and multiply it by 1000 before assigning `_checkIntervalMiliseconds`, but that would have been a breaking change. And the default in .Net framework when specifying intervals/timeouts with an int is milliseconds.