### PR TITLE
Detect encoding in text files

### DIFF
--- a/source/LogFlow.Specifications/EncodingDetection/EncodingDetectorSpecs.cs
+++ b/source/LogFlow.Specifications/EncodingDetection/EncodingDetectorSpecs.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using LogFlow.EncodingDetection;
+using Xunit;
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
+
+namespace LogFlow.Specifications.EncodingDetection
+{
+	public class EncodingDetectorSpecs
+	{
+		[Theory, MemberData("Data_CorrectPreambles")]
+		public void Given_correct_preambles_Then_it_should_detect_correctly(Data data)
+		{
+			PerformTest(data, DetectionResult.EncodingDetected);
+		}
+
+		[Theory, MemberData("Data_TooShortPreambles")]
+		public void Given_to_short_preambles_Then_it_should_report_ToFewBytesToDetermine(Data data)
+		{
+			PerformTest(data, DetectionResult.ToFewBytesToDetermine);
+		}
+
+		[Theory, MemberData("Data_LooksLikePreambles")]
+		public void Given_starts_that_resembles_preambles_Then_it_should_report_NoEncoding(Data data)
+		{
+			PerformTest(data, DetectionResult.NoEncoding);
+		}
+
+		private static void PerformTest(Data data, DetectionResult expectedResult)
+		{
+			var detector = new EncodingDetector();
+			var memoryStream = new MemoryStream(data.Bytes);
+
+			var result = detector.DetectEncoding(memoryStream);
+
+			Assert.Equal(expectedResult, result.Result);
+			Assert.Equal(data.Expected, result.Encoding);
+			Assert.Equal(data.ExpectedPosition, memoryStream.Position);
+		}
+
+		private static readonly IEnumerable<Encoding> _supportedEncodingsExceptUTF16le = new[]
+		{
+			Encoding.UTF8,
+			Encoding.BigEndianUnicode,     //UTF-16 Big Endian
+			Encoding.UTF32,                //UTF-32 Little Endian
+			new UTF32Encoding(true, true), //UTF-32 Big Endian
+		};
+
+		private static readonly IEnumerable<Encoding> _supportedEncodings = _supportedEncodingsExceptUTF16le.Concat(new[]
+		{
+			Encoding.Unicode,              //UTF-16 Little Endian
+		});
+
+
+
+		public static IEnumerable<object[]> Data_CorrectPreambles
+		{
+			get
+			{
+				foreach(var encoding in _supportedEncodingsExceptUTF16le)
+				{
+					var preamble = encoding.GetPreamble();
+
+					//Yield the preamble
+					yield return new object[] { new Data(preamble, preamble, encoding, preamble.Length) };
+
+					//yield one with extra bytes
+					yield return new object[] { new Data(Concat(preamble, (byte)'H', (byte)'i'), preamble, encoding, preamble.Length) };
+				}
+
+				//UTF-16le preamble in it self is not enough to make it distinguishable from UTF-32 Little Endian
+				//   "FF FE"          UTF-16 Little Endian
+				//   "FF FE 00 00"    UTF-32 Little Endian
+				// So we add an extra byte != 00
+				var utf16lePreamble = Encoding.Unicode.GetPreamble();
+				var utf16Bytes = Concat(utf16lePreamble, (byte)'X');
+
+				yield return new object[] { new Data(utf16Bytes, utf16lePreamble, Encoding.Unicode, utf16lePreamble.Length) };
+			}
+		}
+
+
+		public static IEnumerable<object[]> Data_TooShortPreambles
+		{
+			get
+			{
+				//Yield all encodings but with one byte less
+				foreach(var encoding in _supportedEncodings)
+				{
+					var preamble = encoding.GetPreamble();
+					var bytes = RemoveLastByte(preamble);
+					yield return new object[] { new Data(bytes, new byte[0], null, 0) };
+				}
+
+				//UTF-16le preamble in it self is not enough to make it distinguishable from UTF-32 Little Endian
+				//   "FF FE"          UTF-16 Little Endian
+				//   "FF FE 00 00"    UTF-32 Little Endian
+				//So we yield FF FE and it should not be enough to be detected
+				var utf16lePreamble = Encoding.Unicode.GetPreamble();
+				yield return new object[] { new Data(utf16lePreamble, new byte[0], null, 0) };
+
+			}
+		}
+
+		public static IEnumerable<object[]> Data_LooksLikePreambles
+		{
+			get
+			{
+				//Yield preambles that looks like the encoding's preambles but with foreign
+				//character inserted at index 0 and 1
+				foreach(var encoding in _supportedEncodings)
+				{
+					foreach(var position in Enumerable.Range(0, 1))
+					{
+						var preamble = encoding.GetPreamble();
+						var bytes = InsertAtPosition(preamble, position, 'X');
+						yield return new object[] { new Data(bytes, new byte[0], null, 0) };
+					}
+				}
+			}
+		}
+
+		private static byte[] RemoveLastByte(byte[] preamble)
+		{
+			var bytes = new byte[preamble.Length - 1];
+			Array.Copy(preamble, bytes, bytes.Length);
+			return bytes;
+		}
+
+		public static byte[] InsertAtPosition(byte[] array, int position, char extraChar)
+		{
+			var length = array.Length;
+			var newArray = new byte[length + 1];
+			Array.Copy(array, newArray, position);
+			newArray[position] = (byte)extraChar;
+			Array.Copy(array, position, newArray, position + 1, array.Length - position);
+			return newArray;
+		}
+
+
+		public static byte[] Concat(byte[] array, params byte[] items)
+		{
+			var length = array.Length;
+			var newArray = new byte[length + items.Length];
+			Array.Copy(array, newArray, length);
+			Array.Copy(items, 0, newArray, length, items.Length);
+			return newArray;
+		}
+
+		public class Data
+		{
+			public Data(byte[] bytes, byte[] preamble, Encoding expected, int expectedPosition)
+			{
+				Bytes = bytes;
+				Preamble = preamble;
+				Expected = expected;
+				ExpectedPosition = expectedPosition;
+			}
+
+			public byte[] Bytes { get; private set; }
+			public byte[] Preamble { get; private set; }
+			public Encoding Expected { get; private set; }
+			public int ExpectedPosition { get; private set; }
+		}
+	}
+}

--- a/source/LogFlow.Specifications/LogFlow.Specifications.csproj
+++ b/source/LogFlow.Specifications/LogFlow.Specifications.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>a0babbdc</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,8 +54,18 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert">
+      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EncodingDetection\EncodingDetectorSpecs.cs" />
     <Compile Include="Flows\EmptyFlow.cs" />
     <Compile Include="Flows\FlowExecutionSpecs.cs" />
     <Compile Include="Flows\FlowWithoutInput.cs" />
@@ -81,6 +93,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/LogFlow.Specifications/packages.config
+++ b/source/LogFlow.Specifications/packages.config
@@ -3,4 +3,9 @@
   <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/source/LogFlow/Builtins/Inputs/FileInput.cs
+++ b/source/LogFlow/Builtins/Inputs/FileInput.cs
@@ -29,7 +29,7 @@ namespace LogFlow.Builtins.Inputs
 			set
 			{
 				if(value < 100)
-					throw new InvalidDataException("Interval can't be less then 100 miliseconds.");
+					throw new InvalidDataException("Interval can't be less than 100 milliseconds.");
 				
 				_checkIntervalMiliseconds = value;
 			}

--- a/source/LogFlow/Builtins/Inputs/TextFileLineReader.cs
+++ b/source/LogFlow/Builtins/Inputs/TextFileLineReader.cs
@@ -1,20 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using LogFlow.EncodingDetection;
+using NLog;
 
 namespace LogFlow.Builtins.Inputs
 {
 	public sealed class TextFileLineReader : IDisposable
 	{
-
-		FileStream _fileStream = null;
-		BinaryReader _binReader = null;
-		StreamReader _streamReader = null;
-		long _length = -1;
+		private readonly bool _allowChangeEncoding;
+		private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+		private readonly EncodingDetector _encodingDetector;
+		private readonly long _length;
+		private FileStream _fileStream;
+		private BinaryReader _binReader;
+		private Encoding _encoding;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="TextFileLineReader"/> class with default encoding (UTF8).
+		/// Initializes a new instance of the <see cref="TextFileLineReader"/> class. The encoding will default to UTF-8 unless
+		/// the file contains byte order marks for UTF-16 or UTF-32.
 		/// </summary>
 		/// <param name="filePath">The path to text file.</param>
 		public TextFileLineReader(string filePath) : this(filePath, Encoding.UTF8) { }
@@ -24,18 +28,36 @@ namespace LogFlow.Builtins.Inputs
 		/// </summary>
 		/// <param name="filePath">The path to text file.</param>
 		/// <param name="encoding">The encoding of text file.</param>
-		public TextFileLineReader(string filePath, Encoding encoding)
+		/// <param name="encodingDetector">Optional: instance capable of detecting text encodings. 
+		/// If <c>null</c> <see cref="EncodingDetector"/> will be used which can detect files with byte order marks
+		/// for UTF-8, UTF-16 and UTF-32.</param>
+		/// <param name="allowChangeEncoding">Optional: <c>true</c> to allow the reader to change to 
+		/// another encoding if one is detected by <paramref name="encodingDetector"/>. Default is <c>true</c>.</param>
+		public TextFileLineReader(string filePath, Encoding encoding, EncodingDetector encodingDetector = null, bool allowChangeEncoding = true)
 		{
+			_allowChangeEncoding = allowChangeEncoding;
+			_encodingDetector = encodingDetector ?? EncodingDetector.Instance;
+
 			if(!File.Exists(filePath))
 				throw new FileNotFoundException("File (" + filePath + ") is not found.");
 
-			var safeEncoding = (Encoding)encoding.Clone();
-			safeEncoding.DecoderFallback = new DecoderReplacementFallback("");
 
 			_fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 			_length = _fileStream.Length;
-			_binReader = new BinaryReader(_fileStream, safeEncoding);
+			CreateBinaryReader(encoding);
 		}
+
+		private void CreateBinaryReader(Encoding encoding)
+		{
+			var safeEncoding = (Encoding)encoding.Clone();
+			safeEncoding.DecoderFallback = new DecoderReplacementFallback("");
+			if(_binReader != null)
+				_binReader.Dispose();
+
+			_binReader = new BinaryReader(_fileStream, safeEncoding, leaveOpen: true);
+			_encoding = safeEncoding;
+		}
+
 
 		/// <summary>
 		/// Reads a line of characters from the current stream at the current position and returns the data as a string.
@@ -43,8 +65,12 @@ namespace LogFlow.Builtins.Inputs
 		/// <returns>The next line from the input stream, or null if the end of the input stream is reached</returns>
 		public string ReadLine()
 		{
-			if(_binReader.BaseStream.Position == _binReader.BaseStream.Length)
+			var position = _binReader.BaseStream.Position;
+			if(position == _binReader.BaseStream.Length)
 				return null;
+
+			if(position == 0)
+				DetectEncoding();
 
 			string line = "";
 			int nextChar = _binReader.Read();
@@ -65,6 +91,41 @@ namespace LogFlow.Builtins.Inputs
 				nextChar = _binReader.Read();
 			}
 			return line;
+		}
+
+
+		private void DetectEncoding()
+		{
+			var detectedEncoding = _encodingDetector.DetectEncoding(_fileStream);
+			switch(detectedEncoding.Result)
+			{
+				case DetectionResult.EncodingDetected:
+					var isSameEncoding = Equals(detectedEncoding.Encoding, _encoding);
+					if(!isSameEncoding)
+					{
+						if(_allowChangeEncoding)
+						{
+							Log.Trace("User requested encoding {0} but the file {1} uses encoding {2}. Switching to {2}.", _encoding.HeaderName, _fileStream.Name, detectedEncoding.Encoding.HeaderName);
+							CreateBinaryReader(detectedEncoding.Encoding);
+						}
+						else
+						{
+							Log.Trace("User requested encoding {0} but the file {1} uses encoding {2}. User has requested to not change encoding so {0} will be used.", _encoding.HeaderName, _fileStream.Name, detectedEncoding.Encoding.HeaderName);
+						}
+					}
+					else
+					{
+						Log.Trace("Detected encoding {0} for file {1}", detectedEncoding.Encoding.HeaderName, _fileStream.Name);
+					}
+					break;
+				case DetectionResult.NoEncoding:
+					break;
+				case DetectionResult.ToFewBytesToDetermine:
+					//_needToDetectEncoding = true;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
 		}
 
 		/// <summary>
@@ -91,11 +152,11 @@ namespace LogFlow.Builtins.Inputs
 				if(_binReader == null)
 					return;
 
-				this.SetPosition(value >= this.Length ? this.Length : value);
+				SetPosition(value >= this.Length ? this.Length : value);
 			}
 		}
 
-		void SetPosition(long position)
+		private void SetPosition(long position)
 		{
 			_binReader.BaseStream.Seek(position, SeekOrigin.Begin);
 		}
@@ -105,19 +166,19 @@ namespace LogFlow.Builtins.Inputs
 		/// </summary>
 		public void Dispose()
 		{
-			if(_binReader != null)
-				_binReader.Close();
-			if(_streamReader != null)
-			{
-				_streamReader.Close();
-				_streamReader.Dispose();
-			}
 			if(_fileStream != null)
 			{
 				_fileStream.Close();
 				_fileStream.Dispose();
+				_fileStream = null;
+			}
+			if(_binReader != null)
+			{
+				_binReader.Close();
+				_binReader.Dispose();
+				_binReader = null;
 			}
 		}
-		
+
 	}
 }

--- a/source/LogFlow/Builtins/Inputs/TextFileLineReader.cs
+++ b/source/LogFlow/Builtins/Inputs/TextFileLineReader.cs
@@ -15,13 +15,13 @@ namespace LogFlow.Builtins.Inputs
 		long _length = -1;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="TextFileReader"/> class with default encoding (UTF8).
+		/// Initializes a new instance of the <see cref="TextFileLineReader"/> class with default encoding (UTF8).
 		/// </summary>
 		/// <param name="filePath">The path to text file.</param>
 		public TextFileLineReader(string filePath) : this(filePath, Encoding.UTF8) { }
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="TextFileReader"/> class.
+		/// Initializes a new instance of the <see cref="TextFileLineReader"/> class.
 		/// </summary>
 		/// <param name="filePath">The path to text file.</param>
 		/// <param name="encoding">The encoding of text file.</param>

--- a/source/LogFlow/Builtins/Inputs/TextFileLineReader.cs
+++ b/source/LogFlow/Builtins/Inputs/TextFileLineReader.cs
@@ -11,7 +11,6 @@ namespace LogFlow.Builtins.Inputs
 		FileStream _fileStream = null;
 		BinaryReader _binReader = null;
 		StreamReader _streamReader = null;
-		List<string> _lines = null;
 		long _length = -1;
 
 		/// <summary>
@@ -102,17 +101,6 @@ namespace LogFlow.Builtins.Inputs
 		}
 
 		/// <summary>
-		/// Gets the lines after reading.
-		/// </summary>
-		public List<string> Lines
-		{
-			get
-			{
-				return _lines;
-			}
-		}
-
-		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
 		/// </summary>
 		public void Dispose()
@@ -130,10 +118,6 @@ namespace LogFlow.Builtins.Inputs
 				_fileStream.Dispose();
 			}
 		}
-
-		~TextFileLineReader()
-		{
-			this.Dispose();
-		}
+		
 	}
 }

--- a/source/LogFlow/EncodingDetection/DetectedEncoding.cs
+++ b/source/LogFlow/EncodingDetection/DetectedEncoding.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Text;
+
+namespace LogFlow.EncodingDetection
+{
+	/// <summary>
+	/// The result of <see cref="IEncodingDetector.DetectEncoding"/>
+	/// </summary>
+	public struct DetectedEncoding
+	{
+		private static readonly DetectedEncoding _toFewBytesToDetermine = new DetectedEncoding(null, DetectionResult.ToFewBytesToDetermine);
+		private static readonly DetectedEncoding _noEncoding = new DetectedEncoding(null, DetectionResult.NoEncoding);
+
+		private readonly Encoding _encoding;
+		private readonly DetectionResult _result;
+
+		public DetectedEncoding(Encoding encoding)
+		{
+			if(encoding == null) throw new ArgumentNullException("encoding");
+			_encoding = encoding;
+			_result = DetectionResult.EncodingDetected;
+		}
+
+		private DetectedEncoding(Encoding encoding, DetectionResult result)
+		{
+			_encoding = encoding;
+			_result = result;
+		}
+
+		/// <summary>
+		/// Gets the detected encoding. If no encoding was detected, <c>null</c> is returned.
+		/// </summary>
+		public Encoding Encoding { get { return _encoding; } }
+
+		/// <summary>
+		/// Gets the outcome of the detection, i.e. if an encoding was detected or not, or if
+		/// it was indeterminable as to few bytes were available.
+		/// </summary>
+		public DetectionResult Result { get { return _result; } }
+
+		/// <summary>
+		/// Gets the <see cref="DetectedEncoding"/> instance for when it is not possible to determine the encoding due to too few bytes available.
+		/// </summary>
+		public static DetectedEncoding ToFewBytesToDetermine { get { return _toFewBytesToDetermine; } }
+
+		/// <summary>
+		/// Gets the <see cref="DetectedEncoding"/> instance for when no encoding was detected.
+		/// </summary>
+		public static DetectedEncoding NoEncoding { get { return _noEncoding; } }
+	}
+
+}

--- a/source/LogFlow/EncodingDetection/DetectionResult.cs
+++ b/source/LogFlow/EncodingDetection/DetectionResult.cs
@@ -1,0 +1,23 @@
+namespace LogFlow.EncodingDetection
+{
+	/// <summary>
+	/// The outcome of detecting the encoding in <see cref="IEncodingDetector.DetectEncoding"/>
+	/// </summary>
+	public enum DetectionResult
+	{
+		/// <summary>
+		/// An encoding was detected. <see cref="DetectedEncoding.Encoding"/> contains the detected encoding.
+		/// </summary>
+		EncodingDetected,
+
+		/// <summary>
+		/// The stream did not contain any known encodings. <see cref="DetectedEncoding.Encoding"/> will be <c>null</c>.
+		/// </summary>
+		NoEncoding,
+
+		/// <summary>
+		/// The stream did not contain enough number of bytes to determine. You need to recheck when more bytes are available.
+		/// </summary>
+		ToFewBytesToDetermine
+	}
+}

--- a/source/LogFlow/EncodingDetection/EncodingDetector.cs
+++ b/source/LogFlow/EncodingDetection/EncodingDetector.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace LogFlow.EncodingDetection
+{
+	/// <summary>
+	/// Capable of detecting the following byte order marks from a stream.
+	/// <code>
+	///   "EF BB BF"       UTF-8
+	///   "FE FF"          UTF-16 Big Endian
+	///   "FF FE"          UTF-16 Little Endian
+	///   "00 00 FE FF"    UTF-32 Big Endian
+	///   "FF FE 00 00"    UTF-32 Little Endian
+	/// </code>
+	/// </summary>
+	public class EncodingDetector : IEncodingDetector
+	{
+		//As EncodingDetector has no state, we create an instance that can be reused.
+		//However in order for users to create their own implementations based on this 
+		//class the constructor is not made private
+		private static readonly EncodingDetector _instance=new EncodingDetector();
+
+		internal static EncodingDetector Instance { get { return _instance; } }
+
+
+		public virtual DetectedEncoding DetectEncoding(Stream seekableStream)
+		{
+			return DetectEncoding(seekableStream, 4);
+		}
+
+		protected virtual DetectedEncoding DetectEncoding(Stream seekableStream, int maxNumberOfBytesInPreamble)
+		{
+			//Store the current position in the stream. This should normally be 0.
+			var startPosition = seekableStream.Position;
+
+			//Read as many bytes as we need for the preamble from the stream
+			var preamble = new byte[maxNumberOfBytesInPreamble];
+			var bytesRead = seekableStream.Read(preamble, 0, maxNumberOfBytesInPreamble);
+
+			//Detect encoding
+			int preambleLength;
+			var result = DetectEncoding(preamble, bytesRead, out preambleLength);
+
+			//Rewind the stream to the position after the preamble (which, if no preamble was detected, will be the same as startPosition)
+			seekableStream.Position = startPosition + preambleLength;
+			return result;
+		}
+
+		protected virtual DetectedEncoding DetectEncoding(byte[] bytes, int availableBytes, out int preambleLength)
+		{
+			//See http://en.wikipedia.org/wiki/Byte_order_mark for a list of BOMs
+			//Currently this function detects:
+			//   "EF BB BF"       UTF-8
+			//   "FE FF"          UTF-16 Big Endian
+			//   "FF FE"          UTF-16 Little Endian
+			//   "00 00 FE FF"    UTF-32 Big Endian
+			//   "FF FE 00 00"    UTF-32 Little Endian
+
+			preambleLength = 0;
+
+			if(availableBytes < 2)
+			{
+				return DetectedEncoding.ToFewBytesToDetermine;
+			}
+			bool preambleNeedsToBeChecked;
+			Encoding detectedEncoding = null;
+
+			if(bytes[0] == 0xFE && bytes[1] == 0xFF)
+			{
+				detectedEncoding = Encoding.BigEndianUnicode; // "FE FF": UTF-16 Big Endian
+				preambleLength = 2;
+				preambleNeedsToBeChecked = false;
+			}
+			else if(bytes[0] == 0xFF && bytes[1] == 0xFE) // "FF FE"
+			{
+				//We need at least three bytes to be able to distinguish between "FF FE" and "FF FE 00 00"
+				if(availableBytes >= 3)
+				{
+					if(bytes[2] == 0x00) // "FF FE 00"
+					{
+						//We need the fourth byte to be certain we have "FF FE 00 00". If we cannot see what the
+						//fourth byte is, we must wait and redetect once we have more bytes.
+						if(availableBytes >= 4)
+						{
+							if(bytes[3] == 0x00) // "FF FE 00 00"
+							{
+								detectedEncoding = new UTF32Encoding(false, true); // "FF FE 00 00": UTF-32 Little Endian
+								preambleLength = 4;
+								preambleNeedsToBeChecked = false;
+							}
+							else
+							{
+								//We have "FF FE 00 xx" where xx!="00"
+								detectedEncoding = Encoding.Unicode; // "FF FE": UTF-16 Little Endian
+								preambleLength = 2;
+								preambleNeedsToBeChecked = false;
+							}
+						}
+						else
+						{
+							//We have "FF FE 00" but as we don't know what the fourth character is we cannot know for certain which encoding is used
+							preambleNeedsToBeChecked = true;
+						}
+					}
+					else
+					{
+						//We have "FF FE xx" where xx != "00"
+						detectedEncoding = Encoding.Unicode; // "FF FE": UTF-16 Little Endian
+						preambleLength = 2;
+						preambleNeedsToBeChecked = false;
+					}
+				}
+				else
+				{
+					//We have "FF FE" but have to no more bytes than that. It's to few bytes to distinguish between "FF FE" or "FF FE 00 00"
+					preambleNeedsToBeChecked = true;
+				}
+			}
+			else if(bytes[0] == 0xEF && bytes[1] == 0xBB)
+			{
+				if(availableBytes >= 3)
+				{
+					if(bytes[2] == 0xBF)
+					{
+						detectedEncoding = Encoding.UTF8; // "EF BB BF": UTF-8
+						preambleLength = 3;
+						preambleNeedsToBeChecked = false;
+					}
+					else
+						preambleNeedsToBeChecked = false; //Third byte is not BF so no encoding used	
+				}
+				else
+					preambleNeedsToBeChecked = true; //We only have two bytes. The third byte could be BF so we need to recheck
+			}
+			else if(bytes[0] == 0x00 && bytes[1] == 0x00)
+			{
+				if(availableBytes >= 3)
+				{
+					if(bytes[2] == 0xFE)
+					{
+						if(availableBytes >= 4)
+						{
+							if(bytes[3] == 0xFF)
+							{
+								detectedEncoding = new UTF32Encoding(true, true); // "00 00 FE FF": UTF-32 Big Endian
+								preambleLength = 4;
+								preambleNeedsToBeChecked = false;
+							}
+							else
+								preambleNeedsToBeChecked = false; //Fourth byte is not FF so no encoding used	
+						}
+						else
+							preambleNeedsToBeChecked = true; //We only have three bytes. The fourth byte could be FF so we need to recheck
+					}
+					else
+						preambleNeedsToBeChecked = false; //Third byte is not FE so no encoding used	
+				}
+				else
+					preambleNeedsToBeChecked = true; //We only have two bytes. The third byte could be BF so we need to recheck
+			}
+			else
+				preambleNeedsToBeChecked = false;
+
+			if(preambleNeedsToBeChecked)
+				return DetectedEncoding.ToFewBytesToDetermine;
+
+
+			if(detectedEncoding == null)
+				return DetectedEncoding.NoEncoding;
+
+			var detectedPreamble = new Byte[preambleLength];
+			Array.Copy(bytes, detectedPreamble, preambleLength);
+			return new DetectedEncoding(detectedEncoding);
+		}
+	}
+}

--- a/source/LogFlow/EncodingDetection/IEncodingDetector.cs
+++ b/source/LogFlow/EncodingDetection/IEncodingDetector.cs
@@ -1,0 +1,17 @@
+using System.IO;
+
+namespace LogFlow.EncodingDetection
+{
+	/// <summary>
+	/// Detects the encoding in a stream.
+	/// </summary>
+	public interface IEncodingDetector
+	{
+		/// <summary>
+		/// Detects the encoding in a stream. The stream must be seekable as we must be able to rewind the position
+		/// </summary>
+		/// <param name="seekableStream">The stream.</param>
+		/// <returns></returns>
+		DetectedEncoding DetectEncoding(Stream seekableStream);
+	}
+}

--- a/source/LogFlow/EncodingDetection/NoEncodingDetector.cs
+++ b/source/LogFlow/EncodingDetection/NoEncodingDetector.cs
@@ -1,0 +1,22 @@
+using System.IO;
+
+namespace LogFlow.EncodingDetection
+{
+	/// <summary>
+	/// Totally ignores any byte order marks in a file, and always returns <see cref="DetectedEncoding.NoEncoding"/> (no encoding detected).	
+	/// </summary>
+	public class NoEncodingDetector : IEncodingDetector
+	{
+		private static readonly NoEncodingDetector _instance = new NoEncodingDetector();
+
+		private NoEncodingDetector() { }
+
+		public static NoEncodingDetector Instance { get { return _instance; } }
+
+		public DetectedEncoding DetectEncoding(Stream seekableStream)
+		{
+			return DetectedEncoding.NoEncoding;
+		}
+
+	}
+}

--- a/source/LogFlow/LogFlow.csproj
+++ b/source/LogFlow/LogFlow.csproj
@@ -79,6 +79,11 @@
     <Compile Include="Builtins\Processors\IISLog\LogLineFields.cs" />
     <Compile Include="Builtins\Processors\SetEventTimeStampToNow.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="EncodingDetection\DetectedEncoding.cs" />
+    <Compile Include="EncodingDetection\DetectionResult.cs" />
+    <Compile Include="EncodingDetection\EncodingDetector.cs" />
+    <Compile Include="EncodingDetection\IEncodingDetector.cs" />
+    <Compile Include="EncodingDetection\NoEncodingDetector.cs" />
     <Compile Include="FlowBuilder.cs" />
     <Compile Include="JSonKeys.cs" />
     <Compile Include="LogContext.cs" />


### PR DESCRIPTION
This PR adds the functionality of automatically detecting encoding and switch encoding based on [Byte Order Marks (BOM)](http://en.wikipedia.org/wiki/Byte_order_mark) at the beginning of files.
It also fixes #17 __BOM are included in lines sent to processor__.

This PR modifies `TextFileLineReader` and `FileInput` and adds a few new classes.

## What it does
The `TextFileLineReader` starts by reading the 4 first bytes, and looks for UTF-8, UTF-16 (Big and Little endian) and UTF-32 (Big and Little endian) BOMs.

If a BOM is found it's consumed and will not be sent to the user.
If the detected encoding differs from the encoding specified by the user in the constructor, a new `BinaryReader` with correct encoding is created, unless the user has requested to not change encoding when creating the reader.

The detection behavior can be overriden by passing using another `IEncodingDetector`. 
For example the `NoEncodingDetector` will ignore all bytes in the beginning of a file.

If no BOM is detected, the encoding specified by the user is used.

### StreamReader instead of BinaryReader?
One alternative, considered but dismissed, was to switch from `BinaryReader` to a `StreamReader`, which automatically detects encoding, but instead of just skipping the BOMs it removes them and set position to 0. 

So if the stream contains a 3 bytes BOM and then an `"a"`, `BinaryReader` would be at position _3_ after reading the BOM and have `"a"` as next char to read, while `StreamReader` would be at position _0_ and have `"a"` as next char. 
So switching reader would mean that all stored positions in `IStateStorage` that were saved based on `BinaryReader` would be wrong if used on `StreamReader`.


## Removed unnecessary property and finalizer
In `TextFileLineReader` as `_lines` is never updated, `Lines` always returns `null`, so they have been removed.
This IS a breaking change but a reasonable one to do.

Removed finalizer from `TextFileLineReader` as it doesn't hold any references to unmanaged objects, which is what a finalizer is responsible for releasing.
Sure, it holds a reference to `FileStream` but it is managed and it has a destructor. The recommendation is to never have a finalizer on classes that has no unmanaged objects.

## xUnit
As MSpec has no support for datadriven tests xUnit is used for the tests.

Let me know if you want me to change anything or squash the commits. :)